### PR TITLE
feat: add sample article data and search interface stub

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,30 +1,17 @@
-<script setup lang="ts">
-import HelloWorld from './components/HelloWorld.vue'
-</script>
-
 <template>
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="/vite.svg" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://vuejs.org/" target="_blank">
-      <img src="./assets/vue.svg" class="logo vue" alt="Vue logo" />
-    </a>
+  <div id="app">
+    <SearchComponent />
   </div>
-  <HelloWorld msg="Vite + Vue" />
 </template>
 
-<style scoped>
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.vue:hover {
-  filter: drop-shadow(0 0 2em #42b883aa);
-}
-</style>
+<script lang="ts">
+import { defineComponent } from 'vue';
+import SearchComponent from './components/SearchComponent.vue';
+
+export default defineComponent({
+  name: 'App',
+  components: {
+    SearchComponent
+  }
+});
+</script>

--- a/src/components/SearchComponent.vue
+++ b/src/components/SearchComponent.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <input v-model="searchQuery" placeholder="Search..." />
+    <div v-for="article in filteredArticles" :key="article.id">
+      <h3>{{ article.title }}</h3>
+      <p>{{ article.content }}</p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed } from 'vue';
+import { ARTICLES } from '../data/articles';
+
+export default defineComponent({
+  name: 'SearchComponent',
+  setup() {
+    const searchQuery = ref('');
+    
+    const filteredArticles = computed(() => {
+      return ARTICLES;
+    });
+
+    return {
+      searchQuery,
+      filteredArticles
+    };
+  }
+});
+</script>

--- a/src/data/articles.ts
+++ b/src/data/articles.ts
@@ -1,0 +1,33 @@
+export interface Article {
+  id: number;
+  title: string;
+  content: string;
+}
+
+export const ARTICLES: Article[] = [
+  {
+    id: 1,
+    title: "Introduction to Vue 3",
+    content: "Vue 3 is the latest version of the progressive JavaScript framework. It introduces Composition API, better TypeScript support, and improved performance through the new reactivity system."
+  },
+  {
+    id: 2,
+    title: "Getting Started with TypeScript",
+    content: "TypeScript is a superset of JavaScript that adds static typing. It helps catch errors during development and provides better tooling support for large applications."
+  },
+  {
+    id: 3,
+    title: "Responsive Design Principles",
+    content: "Responsive web design ensures your application looks great on all devices. Use flexible grids, media queries, and mobile-first approaches to create adaptable layouts."
+  },
+  {
+    id: 4,
+    title: "DaisyUI Component Library",
+    content: "DaisyUI is a Tailwind CSS component library that provides ready-to-use components with built-in themes. It simplifies UI development while maintaining customization flexibility."
+  },
+  {
+    id: 5,
+    title: "State Management in Vue",
+    content: "Vuex and Pinia are popular state management solutions for Vue applications. They help manage global state in a predictable way, especially in complex applications."
+  }
+];


### PR DESCRIPTION
**Changes:**
- Create `src/data/articles.ts` with typed `Article[]` constant
- Define `Article` TypeScript interface
- Add empty `SearchComponent.vue` with:
  - `searchQuery` ref
  - `filteredArticles` computed (returns all articles initially)
  - Basic template structure (input + article list placeholders)
- Register component in `App.vue` for testing

**Why?**
Isolates data modeling and sets up the foundation without UI or logic complexity.